### PR TITLE
Poistettu system property log4j.debug.

### DIFF
--- a/variants/war-openjdk11/run.sh
+++ b/variants/war-openjdk11/run.sh
@@ -91,7 +91,6 @@ JAVA_OPTS="$JAVA_OPTS
   ${SECRET_JAVA_OPTS}
   -Duser.home=/home/oph
   -Djavax.net.ssl.trustStore=${HOME}/cacerts
-  -Dlog4j.debug=true
   -Djava.util.logging.config.file=${LOGPATH}/logging.properties
   -Djuli-logback.configurationFile=file://${LOGPATH}/logback-tomcat.xml
   -DHOSTNAME=`hostname`

--- a/variants/war-openjdk8/run.sh
+++ b/variants/war-openjdk8/run.sh
@@ -91,7 +91,6 @@ JAVA_OPTS="$JAVA_OPTS
   ${SECRET_JAVA_OPTS}
   -Duser.home=/home/oph
   -Djavax.net.ssl.trustStore=${HOME}/cacerts
-  -Dlog4j.debug=true
   -Djava.util.logging.config.file=${LOGPATH}/logging.properties
   -Djuli-logback.configurationFile=file://${LOGPATH}/logback-tomcat.xml
   -DHOSTNAME=`hostname`


### PR DESCRIPTION
Jos Log4J:n konffia haluaa debugata, propertyn voi
asettaa JAVA_OPTSin kautta, mutta pääsääntöisesti sitä
ei tarvita. Log4J2:n kohdalla se aiheuttaa kiusallista
jatkuvaa lokin spämmäystä.