### PR TITLE
Remove all ssm agent -related stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,7 @@
 ARG OPENJDK_VERSION
-ARG SERVICE_KIND
-
-FROM golang:1.14-alpine as ssmbuilder
-ARG SSM_AGENT_VERSION=2.3.930.0
-RUN set -ex && apk add --no-cache make git gcc libc-dev curl bash && \
-    curl -sLO https://github.com/aws/amazon-ssm-agent/archive/${SSM_AGENT_VERSION}.tar.gz && \
-    mkdir -p /go/src/github.com && \
-    tar xzf ${SSM_AGENT_VERSION}.tar.gz && \
-    mv amazon-ssm-agent-${SSM_AGENT_VERSION} /go/src/github.com/amazon-ssm-agent && \
-    cd /go/src/github.com/amazon-ssm-agent && \
-    echo ${SSM_AGENT_VERSION} > /go/src/github.com/amazon-ssm-agent/SSM_AGENT_VERSION && \
-    gofmt -w agent && make checkstyle || ./Tools/bin/goimports -w agent && \
-    make build-linux
-
 FROM adoptopenjdk/${OPENJDK_VERSION}:alpine-slim
+
+# need to repeat the argument declaration after FROM for it to be back in scope
 ARG OPENJDK_VERSION
 ARG SERVICE_KIND
 
@@ -34,21 +22,6 @@ RUN \
   sh install.sh && \
   sh test.sh && \
   rm *.sh
-
-COPY ci-tools/ssm_agent/ssm_agent.py /usr/local/bin
-COPY ci-tools/ssm_agent/requirements.txt /tmp
-RUN apk add musl-dev python3-dev gcc linux-headers && \
-    pip3 install -r /tmp/requirements.txt && \
-    apk add fontconfig ttf-dejavu && \
-    apk del musl-dev python3-dev gcc linux-headers
-RUN set -ex && apk add --no-cache sudo ca-certificates && \
-    adduser -D ssm-user && echo "ssm-user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ssm-agent-users && \
-    echo "oph ALL=(ALL:ALL) NOPASSWD: /usr/bin/amazon-ssm-agent" >> /etc/sudoers && \
-    mkdir -p /etc/amazon/ssm
-COPY --from=ssmbuilder /go/src/github.com/amazon-ssm-agent/bin/linux_amd64/ /usr/bin
-COPY --from=ssmbuilder /go/src/github.com/amazon-ssm-agent/bin/amazon-ssm-agent.json.template /etc/amazon/ssm/amazon-ssm-agent.json
-COPY --from=ssmbuilder /go/src/github.com/amazon-ssm-agent/bin/seelog_unix.xml /etc/amazon/ssm/seelog.xml
-RUN ln -s /tmp/log/amazon /var/log/amazon && ln -s /tmp/lib/amazon /var/lib/amazon
 
 RUN echo "Remove /root and symlink /root to /home/oph for backwards compatibility"
 RUN rm -rf /root && \

--- a/variants/fatjar-openjdk11/run.sh
+++ b/variants/fatjar-openjdk11/run.sh
@@ -7,8 +7,6 @@ CONFIGPATH="/home/oph/oph-environment"
 VARS="${CONFIGPATH}/opintopolku.yml"
 LOGPATH="${CONFIGPATH}/log"
 
-mkdir -p /tmp/log/amazon/ssm && mkdir -p /tmp/lib/amazon/ssm
-
 echo "Copying templates to home directory"
 cp -vr /etc/oph/. ${BASEPATH}
 
@@ -53,9 +51,6 @@ export JMX_PORT=1133
 
 echo "Starting Prometheus node_exporter..."
 nohup /usr/local/bin/node_exporter > /home/oph/node_exporter.log  2>&1 &
-
-echo "Starting SSM agent API..."
-nohup /usr/local/bin/ssm_agent.py > /dev/null 2>&1 &
 
 if [ ${DEBUG_ENABLED} == "true" ]; then
   echo "JDWP debugging enabled..."

--- a/variants/fatjar-openjdk8/run.sh
+++ b/variants/fatjar-openjdk8/run.sh
@@ -7,8 +7,6 @@ CONFIGPATH="/home/oph/oph-environment"
 VARS="${CONFIGPATH}/opintopolku.yml"
 LOGPATH="${CONFIGPATH}/log"
 
-mkdir -p /tmp/log/amazon/ssm && mkdir -p /tmp/lib/amazon/ssm
-
 echo "Copying templates to home directory"
 cp -vr /etc/oph/. ${BASEPATH}
 
@@ -53,9 +51,6 @@ export JMX_PORT=1133
 
 echo "Starting Prometheus node_exporter..."
 nohup /usr/local/bin/node_exporter > /home/oph/node_exporter.log  2>&1 &
-
-echo "Starting SSM agent API..."
-nohup /usr/local/bin/ssm_agent.py > /dev/null 2>&1 &
 
 if [ ${DEBUG_ENABLED} == "true" ]; then
   echo "JDWP debugging enabled..."

--- a/variants/war-openjdk11/run.sh
+++ b/variants/war-openjdk11/run.sh
@@ -10,8 +10,6 @@ export CATALINA_BASE="/home/oph/tomcat"
 export CATALINA_HOME="/opt/tomcat"
 export CATALINA_TMPDIR="/tmp/catalina_temp"
 
-mkdir -p /tmp/log/amazon/ssm && mkdir -p /tmp/lib/amazon/ssm
-
 echo "Copying templates to home directory"
 cp -vr /etc/oph/. ${BASEPATH}
 
@@ -69,9 +67,6 @@ cp -vr /opt/tomcat/conf/* ${CATALINA_BASE}/conf/
 
 echo "Starting Prometheus node_exporter..."
 nohup /usr/local/bin/node_exporter > /home/oph/node_exporter.log  2>&1 &
-
-echo "Starting SSM agent API..."
-nohup /usr/local/bin/ssm_agent.py > /dev/null 2>&1 &
 
 if [ ${DEBUG_ENABLED} == "true" ]; then
   echo "JDWP debugging enabled..."

--- a/variants/war-openjdk8/run.sh
+++ b/variants/war-openjdk8/run.sh
@@ -10,8 +10,6 @@ export CATALINA_BASE="/home/oph/tomcat"
 export CATALINA_HOME="/opt/tomcat"
 export CATALINA_TMPDIR="/tmp/catalina_temp"
 
-mkdir -p /tmp/log/amazon/ssm && mkdir -p /tmp/lib/amazon/ssm
-
 echo "Copying templates to home directory"
 cp -vr /etc/oph/. ${BASEPATH}
 
@@ -69,9 +67,6 @@ cp -vr /opt/tomcat/conf/* ${CATALINA_BASE}/conf/
 
 echo "Starting Prometheus node_exporter..."
 nohup /usr/local/bin/node_exporter > /home/oph/node_exporter.log  2>&1 &
-
-echo "Starting SSM agent API..."
-nohup /usr/local/bin/ssm_agent.py > /dev/null 2>&1 &
 
 if [ ${DEBUG_ENABLED} == "true" ]; then
   echo "JDWP debugging enabled..."


### PR DESCRIPTION
This was designed to allow getting a shell in baseimage-based
ECS tasks when we move to Fargate, but now we have a better
solution for the same purpose.

This reverts commit a016363dfd133fd25a76f1dbb761e14b126c8d81.