### PR TITLE
OK-636: create environment variables that can be used for controlling Java startup options

### DIFF
--- a/variants/fatjar-openjdk11/run.sh
+++ b/variants/fatjar-openjdk11/run.sh
@@ -72,78 +72,78 @@ echo "Using java options: ${JAVA_OPTS}"
 echo "Using secret java options: ${SECRET_JAVA_OPTS}"
 
 STANDALONE_JAR=/usr/local/bin/${NAME}.jar
-if [ -f "${STANDALONE_JAR}" ]; then
-    echo "Starting standalone application... ${NAME}"
-
-    # Service-specific boot-time exceptions
-    if [ ${NAME} == "suoritusrekisteri" ]; then
-      echo "Create common.properties"
-      cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
-
-      YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
-      if [ -f "${YTLCERT}" ]; then
-        echo "Installing YTL certificate for suoritusrekisteri"
-        TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
-        keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
-      fi
-    elif [ ${NAME} == "ataru-hakija" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-hakija"
-    elif [ ${NAME} == "ataru-editori" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-editori"
-    fi
-
-    export HOME="/home/oph"
-    export LOGS="${HOME}/logs"
-
-    if [[ "${NAME}" =~ ^ovara ]]; then
-      echo "ovara java_opts: ${JAVA_OPTS}"
-    else
-      JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
-      JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
-      JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
-      JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
-      JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-      JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
-      JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
-      if [ ${NAME} == "liiteri" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
-      elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-      elif [ ${NAME} == "oti" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-      else
-          # at least hakuperusteet seems to need this
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
-      fi
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
-      JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
-      JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
-      JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-      JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
-      JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'" 
-      JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
-      JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
-      JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
-      JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
-      JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
-      JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
-    fi
-    JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
-    echo $JAVA_CMD | tee /home/oph/java-cmd.txt
-    eval $JAVA_CMD
-else
+if [ ! -f "${STANDALONE_JAR}" ]; then
   echo "Fatal error: No fatjar found, exiting!"
   exit 1
 fi
+
+echo "Starting standalone application... ${NAME}"
+
+# Service-specific boot-time exceptions
+if [ ${NAME} == "suoritusrekisteri" ]; then
+    echo "Create common.properties"
+    cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
+
+    YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
+    if [ -f "${YTLCERT}" ]; then
+	echo "Installing YTL certificate for suoritusrekisteri"
+	TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
+	keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
+    fi
+elif [ ${NAME} == "ataru-hakija" ]; then
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-hakija"
+elif [ ${NAME} == "ataru-editori" ]; then
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-editori"
+fi
+
+export HOME="/home/oph"
+export LOGS="${HOME}/logs"
+
+if [[ "${NAME}" =~ ^ovara ]]; then
+    echo "ovara java_opts: ${JAVA_OPTS}"
+else
+    JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
+    JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
+    JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
+    JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
+    JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+    JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
+    JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
+    if [ ${NAME} == "liiteri" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
+    elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+    elif [ ${NAME} == "oti" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+    else
+	# at least hakuperusteet seems to need this
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+    fi
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
+    JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
+    JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
+    JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
+    JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'" 
+    JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+    JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
+    JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
+    JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
+    JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
+    JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+fi
+JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
+echo $JAVA_CMD | tee /home/oph/java-cmd.txt
+eval $JAVA_CMD

--- a/variants/fatjar-openjdk17/run.sh
+++ b/variants/fatjar-openjdk17/run.sh
@@ -81,73 +81,85 @@ echo "Starting standalone application... ${NAME}"
 
 # Service-specific boot-time exceptions
 if [ ${NAME} == "suoritusrekisteri" ]; then
-  echo "Create common.properties"
-  cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
+    echo "Create common.properties"
+    cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
 
-  YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
-  if [ -f "${YTLCERT}" ]; then
-    echo "Installing YTL certificate for suoritusrekisteri"
-    TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
-    keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
-  fi
+    YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
+    if [ -f "${YTLCERT}" ]; then
+	echo "Installing YTL certificate for suoritusrekisteri"
+	TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
+	keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
+    fi
 elif [ ${NAME} == "ataru-hakija" ]; then
-  export ATARU_HTTP_PORT=8080
-  export CONFIG=/home/oph/oph-configuration/config.edn
-  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-  export APP="ataru-hakija"
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-hakija"
 elif [ ${NAME} == "ataru-editori" ]; then
-  export ATARU_HTTP_PORT=8080
-  export CONFIG=/home/oph/oph-configuration/config.edn
-  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-  export APP="ataru-editori"
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-editori"
 elif [ ${NAME} == "ovara-ataru" ]; then
-  echo "Using ovara-ataru configuration"
-  export CONFIG=/home/oph/ovara-configuration/ovara-config.edn
-  export CONFIGDEFAULTS=/home/oph/ovara-configuration/ovara-config.edn
+    echo "Using ovara-ataru configuration"
+    export CONFIG=/home/oph/ovara-configuration/ovara-config.edn
+    export CONFIGDEFAULTS=/home/oph/ovara-configuration/ovara-config.edn
 fi
 
 export HOME="/home/oph"
 export LOGS="${HOME}/logs"
 
-if [[ "${NAME}" =~ ^ovara ]]; then
-  echo "ovara java_opts: ${JAVA_OPTS}"
-else
-  JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
-  JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
-  JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
-  JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
-  JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-  JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
-  JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
-  JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
-  if [ ${NAME} == "liiteri" ]; then
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
-  elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-  elif [ ${NAME} == "oti" ]; then
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-  else
-      # at least hakuperusteet seems to need this
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
-  fi
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
-  JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
-  JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
-  JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-  JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
-  JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
-  JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
-  JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
-  JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
-  JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
-  JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
-  JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+if [[ "X${DONT_INCLUDE_DEFAULT_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
+    JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
+    JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
+    JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
+    JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+    JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+    JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
+    JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
 fi
+
+if [[ "X${DONT_INCLUDE_LOGBACK_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
+    JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
+    if [ ${NAME} == "liiteri" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
+    elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+    elif [ ${NAME} == "oti" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+    else
+	# at least hakuperusteet seems to need this
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+    fi
+fi
+
+if [[ "X${DONT_INCLUDE_DEBUGGER_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
+    JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
+fi
+
+if [[ "X${DONT_INCLUDE_MEMORY_LOGS_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
+    JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+fi
+
+if [[ "X${DONT_INCLUDE_MEMORY_MANAGEMENT_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
+    JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
+fi
+
+JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
+JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
+JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+
 JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
 echo $JAVA_CMD | tee /home/oph/java-cmd.txt
 eval $JAVA_CMD

--- a/variants/fatjar-openjdk17/run.sh
+++ b/variants/fatjar-openjdk17/run.sh
@@ -72,82 +72,82 @@ echo "Using java options: ${JAVA_OPTS}"
 echo "Using secret java options: ${SECRET_JAVA_OPTS}"
 
 STANDALONE_JAR=/usr/local/bin/${NAME}.jar
-if [ -f "${STANDALONE_JAR}" ]; then
-    echo "Starting standalone application... ${NAME}"
-
-    # Service-specific boot-time exceptions
-    if [ ${NAME} == "suoritusrekisteri" ]; then
-      echo "Create common.properties"
-      cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
-
-      YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
-      if [ -f "${YTLCERT}" ]; then
-        echo "Installing YTL certificate for suoritusrekisteri"
-        TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
-        keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
-      fi
-    elif [ ${NAME} == "ataru-hakija" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-hakija"
-    elif [ ${NAME} == "ataru-editori" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-editori"
-    elif [ ${NAME} == "ovara-ataru" ]; then
-      echo "Using ovara-ataru configuration"
-      export CONFIG=/home/oph/ovara-configuration/ovara-config.edn
-      export CONFIGDEFAULTS=/home/oph/ovara-configuration/ovara-config.edn
-    fi
-
-    export HOME="/home/oph"
-    export LOGS="${HOME}/logs"
-
-    if [[ "${NAME}" =~ ^ovara ]]; then
-      echo "ovara java_opts: ${JAVA_OPTS}"
-    else
-      JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
-      JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
-      JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
-      JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
-      JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-      JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
-      JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
-      JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
-      if [ ${NAME} == "liiteri" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
-      elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-      elif [ ${NAME} == "oti" ]; then
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-      else
-          # at least hakuperusteet seems to need this
-          JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
-      fi
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-      JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
-      JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
-      JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
-      JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-      JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
-      JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
-      JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
-      JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
-      JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
-      JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
-      JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
-      JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
-    fi
-    JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
-    echo $JAVA_CMD | tee /home/oph/java-cmd.txt
-    eval $JAVA_CMD
-else
+if [ ! -f "${STANDALONE_JAR}" ]; then
   echo "Fatal error: No fatjar found, exiting!"
   exit 1
 fi
+
+echo "Starting standalone application... ${NAME}"
+
+# Service-specific boot-time exceptions
+if [ ${NAME} == "suoritusrekisteri" ]; then
+  echo "Create common.properties"
+  cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
+
+  YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
+  if [ -f "${YTLCERT}" ]; then
+    echo "Installing YTL certificate for suoritusrekisteri"
+    TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
+    keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
+  fi
+elif [ ${NAME} == "ataru-hakija" ]; then
+  export ATARU_HTTP_PORT=8080
+  export CONFIG=/home/oph/oph-configuration/config.edn
+  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+  export APP="ataru-hakija"
+elif [ ${NAME} == "ataru-editori" ]; then
+  export ATARU_HTTP_PORT=8080
+  export CONFIG=/home/oph/oph-configuration/config.edn
+  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+  export APP="ataru-editori"
+elif [ ${NAME} == "ovara-ataru" ]; then
+  echo "Using ovara-ataru configuration"
+  export CONFIG=/home/oph/ovara-configuration/ovara-config.edn
+  export CONFIGDEFAULTS=/home/oph/ovara-configuration/ovara-config.edn
+fi
+
+export HOME="/home/oph"
+export LOGS="${HOME}/logs"
+
+if [[ "${NAME}" =~ ^ovara ]]; then
+  echo "ovara java_opts: ${JAVA_OPTS}"
+else
+  JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
+  JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
+  JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
+  JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
+  JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+  JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+  JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
+  JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
+  if [ ${NAME} == "liiteri" ]; then
+      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
+  elif [ ${NAME} == "virkailijan-tyopoyta" ]; then
+      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+  elif [ ${NAME} == "oti" ]; then
+      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+  else
+      # at least hakuperusteet seems to need this
+      JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+  fi
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+  JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
+  JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
+  JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
+  JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+  JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
+  JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
+  JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+  JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
+  JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
+  JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
+  JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
+  JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+fi
+JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
+echo $JAVA_CMD | tee /home/oph/java-cmd.txt
+eval $JAVA_CMD

--- a/variants/fatjar-openjdk21/run.sh
+++ b/variants/fatjar-openjdk21/run.sh
@@ -72,74 +72,74 @@ echo "Using java options: ${JAVA_OPTS}"
 echo "Using secret java options: ${SECRET_JAVA_OPTS}"
 
 STANDALONE_JAR=/usr/local/bin/${NAME}.jar
-if [ -f "${STANDALONE_JAR}" ]; then
-    echo "Starting standalone application..."
-
-    # Service-specific boot-time exceptions
-    if [ ${NAME} == "suoritusrekisteri" ]; then
-      echo "Create common.properties"
-      cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
-
-      YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
-      if [ -f "${YTLCERT}" ]; then
-        echo "Installing YTL certificate for suoritusrekisteri"
-        TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
-        keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
-      fi
-    elif [ ${NAME} == "ataru-hakija" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-hakija"
-    elif [ ${NAME} == "ataru-editori" ]; then
-      export ATARU_HTTP_PORT=8080
-      export CONFIG=/home/oph/oph-configuration/config.edn
-      export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-      export APP="ataru-editori"
-    fi
-
-    export HOME="/home/oph"
-    export LOGS="${HOME}/logs"
-
-    JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
-    JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
-    JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
-    JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
-    JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-    JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
-    JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
-    JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
-    if [ ${NAME} == "liiteri" ]; then
-        JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
-    elif [ ${NAME} == "virkailijan-tyopoyta" ] || [ ${NAME} == "oti" ]; then
-        JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-    elif [ ${NAME} == "oma-opintopolku" ] || [ ${NAME} == "ohjausparametrit" ] || [ ${NAME} == "valintalaskenta-ui" ] || [ ${NAME} == "valintaperusteet-ui" ] || [ ${NAME} == "lokalisointi" ]; then
-        echo "${NAME}"
-    else
-        # at least hakuperusteet seems to need this
-        JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
-    fi
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
-    JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
-    JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
-    JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-    JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
-    JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
-    JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
-    JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
-    JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
-    JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
-    JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
-    JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
-    JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
-    echo $JAVA_CMD | tee /home/oph/java-cmd.txt
-    eval $JAVA_CMD
-else
+if [ ! -f "${STANDALONE_JAR}" ]; then
   echo "Fatal error: No fatjar found, exiting!"
   exit 1
 fi
+
+echo "Starting standalone application... ${NAME}"
+
+# Service-specific boot-time exceptions
+if [ ${NAME} == "suoritusrekisteri" ]; then
+  echo "Create common.properties"
+  cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
+
+  YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
+  if [ -f "${YTLCERT}" ]; then
+    echo "Installing YTL certificate for suoritusrekisteri"
+    TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
+    keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
+  fi
+elif [ ${NAME} == "ataru-hakija" ]; then
+  export ATARU_HTTP_PORT=8080
+  export CONFIG=/home/oph/oph-configuration/config.edn
+  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+  export APP="ataru-hakija"
+elif [ ${NAME} == "ataru-editori" ]; then
+  export ATARU_HTTP_PORT=8080
+  export CONFIG=/home/oph/oph-configuration/config.edn
+  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+  export APP="ataru-editori"
+fi
+
+export HOME="/home/oph"
+export LOGS="${HOME}/logs"
+
+JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
+JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
+JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
+JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
+JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
+JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
+JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
+JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
+if [ ${NAME} == "liiteri" ]; then
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
+elif [ ${NAME} == "virkailijan-tyopoyta" ] || [ ${NAME} == "oti" ]; then
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+elif [ ${NAME} == "oma-opintopolku" ] || [ ${NAME} == "ohjausparametrit" ] || [ ${NAME} == "valintalaskenta-ui" ] || [ ${NAME} == "valintaperusteet-ui" ] || [ ${NAME} == "lokalisointi" ]; then
+    echo "${NAME}"
+else
+    # at least hakuperusteet seems to need this
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+fi
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
+JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
+JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
+JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
+JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
+JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
+JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
+JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
+echo $JAVA_CMD | tee /home/oph/java-cmd.txt
+eval $JAVA_CMD

--- a/variants/fatjar-openjdk21/run.sh
+++ b/variants/fatjar-openjdk21/run.sh
@@ -81,65 +81,81 @@ echo "Starting standalone application... ${NAME}"
 
 # Service-specific boot-time exceptions
 if [ ${NAME} == "suoritusrekisteri" ]; then
-  echo "Create common.properties"
-  cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
+    echo "Create common.properties"
+    cp -fv ${BASEPATH}/oph-configuration/${NAME}.properties ${BASEPATH}/oph-configuration/common.properties
 
-  YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
-  if [ -f "${YTLCERT}" ]; then
-    echo "Installing YTL certificate for suoritusrekisteri"
-    TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
-    keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
-  fi
+    YTLCERT="${CONFIGPATH}/suoritusrekisteri/ytlqa.crt"
+    if [ -f "${YTLCERT}" ]; then
+	echo "Installing YTL certificate for suoritusrekisteri"
+	TRUSTSTORE_PWD=$(grep "java_cacerts_pwd" /home/oph/oph-environment/opintopolku.yml | cut -d ":" -f 2 | sed "s/^ *//g")
+	keytool -import -noprompt -trustcacerts -alias ytl_qa_cert -storepass ${TRUSTSTORE_PWD} -keystore /home/oph/cacerts -file ${YTLCERT}
+    fi
 elif [ ${NAME} == "ataru-hakija" ]; then
-  export ATARU_HTTP_PORT=8080
-  export CONFIG=/home/oph/oph-configuration/config.edn
-  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-  export APP="ataru-hakija"
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-hakija"
 elif [ ${NAME} == "ataru-editori" ]; then
-  export ATARU_HTTP_PORT=8080
-  export CONFIG=/home/oph/oph-configuration/config.edn
-  export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
-  export APP="ataru-editori"
+    export ATARU_HTTP_PORT=8080
+    export CONFIG=/home/oph/oph-configuration/config.edn
+    export CONFIGDEFAULTS=/home/oph/oph-configuration/config.edn
+    export APP="ataru-editori"
 fi
 
 export HOME="/home/oph"
 export LOGS="${HOME}/logs"
 
-JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
-JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
-JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
-JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
-JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
-JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
-JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
-JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
-JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
-if [ ${NAME} == "liiteri" ]; then
-    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
-elif [ ${NAME} == "virkailijan-tyopoyta" ] || [ ${NAME} == "oti" ]; then
-    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
-elif [ ${NAME} == "oma-opintopolku" ] || [ ${NAME} == "ohjausparametrit" ] || [ ${NAME} == "valintalaskenta-ui" ] || [ ${NAME} == "valintaperusteet-ui" ] || [ ${NAME} == "lokalisointi" ]; then
-    echo "${NAME}"
-else
-    # at least hakuperusteet seems to need this
-    JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+if [[ "X${DONT_INCLUDE_DEFAULT_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Duser.home=${HOME}"
+    JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=${HOME}/cacerts"
+    JAVA_OPTS="$JAVA_OPTS -DHOSTNAME=`hostname`"
+    JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/urandom"
+    JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+    JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+    JAVA_OPTS="$JAVA_OPTS -Djava.rmi.server.hostname=localhost"
+    JAVA_OPTS="$JAVA_OPTS -D${NAME}.properties=${HOME}/oph-configuration/${NAME}.properties"
 fi
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
-JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
-JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
-JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
-JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
-JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
-JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+
+if [[ "X${DONT_INCLUDE_LOGBACK_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Dlogback.access=${LOGPATH}/logback-access.xml"
+    JAVA_OPTS="$JAVA_OPTS -Dlogbackaccess.configurationFile=${LOGPATH}/logback-access.xml"
+    if [ ${NAME} == "liiteri" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-liiteri.xml"
+    elif [ ${NAME} == "virkailijan-tyopoyta" ] || [ ${NAME} == "oti" ]; then
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${HOME}/oph-configuration/logback.xml"
+    elif [ ${NAME} == "oma-opintopolku" ] || [ ${NAME} == "ohjausparametrit" ] || [ ${NAME} == "valintalaskenta-ui" ] || [ ${NAME} == "valintaperusteet-ui" ] || [ ${NAME} == "lokalisointi" ]; then
+	echo "${NAME}"
+    else
+	# at least hakuperusteet seems to need this
+	JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=${LOGPATH}/logback-standalone.xml"
+    fi
+fi
+
+if [[ "X${DONT_INCLUDE_DEBUGGER_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT}"
+    JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote.local.only=false"
+    JAVA_OPTS="$JAVA_OPTS -javaagent:/usr/local/bin/jmx_prometheus_javaagent.jar=1134:/etc/prometheus.yaml"
+fi
+
+if [[ "X${DONT_INCLUDE_MEMORY_LOGS_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -Xlog:gc*:file=${LOGS}/${NAME}_gc.log:uptime:filecount=10,filesize=10m"
+    JAVA_OPTS="$JAVA_OPTS -XX:ErrorFile=${LOGS}/${NAME}_hs_err.log"
+fi
+
+if [[ "X${DONT_INCLUDE_MEMORY_MANAGEMENT_CONFIG}" == X && ! "${NAME}" =~ ^ovara ]]; then
+    JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+    JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=/tmp/heap_dump.hprof"
+    JAVA_OPTS="$JAVA_OPTS -XX:OnOutOfMemoryError='aws s3 mv /tmp/heap_dump.hprof s3://${ENV_NAME}-crash-dumps/${NAME}/`date +%F_%T`.hprof --no-progress ; kill -9 %p'"
+fi
+
 JAVA_OPTS="$JAVA_OPTS ${TRACE_PARAMS}"
 JAVA_OPTS="$JAVA_OPTS ${SECRET_JAVA_OPTS}"
 JAVA_OPTS="$JAVA_OPTS ${DEBUG_PARAMS}"
+
 JAVA_CMD="java ${JAVA_OPTS} -jar ${STANDALONE_JAR}"
 echo $JAVA_CMD | tee /home/oph/java-cmd.txt
 eval $JAVA_CMD

--- a/variants/fatjar-openjdk8/install.sh
+++ b/variants/fatjar-openjdk8/install.sh
@@ -59,7 +59,7 @@ echo "Installing Bouncy Castle bcprov security provider"
 BCPROV_DL_PREFIX="https://downloads.bouncycastle.org/java"
 BCPROV_PACKAGE="bcprov-jdk15to18-1.78.1.jar"
 wget -c -q -P ${JAVA_HOME}/lib/ext/ ${BCPROV_DL_PREFIX}/${BCPROV_PACKAGE}
-echo "655f03362e09b7e7d8b4530d6fbc1ef0c75ab2fd28ccf71eb8515f4cc023cc8a  ${JAVA_HOME}/lib/ext/${BCPROV_PACKAGE}" |sha256sum -c
+echo "b6758a0a72ed44dfdb316e50a67919cc4640e160a26b8a7e9d989cdcb3fc8a7f  ${JAVA_HOME}/lib/ext/${BCPROV_PACKAGE}" |sha256sum -c
 
 echo "Updating java.security"
 JAVA_SECURITY_FILE=$JAVA_HOME/lib/security/java.security


### PR DESCRIPTION
This is originally because batch jobs are run without an initializer container, so the logback options are actually wrong for them.  Ovara was special-cased for the same reason, but I'm creating a more generic mechanism for picking default options for running the fatjar in the image.

When/if this is merged, it will be used here: https://github.com/Opetushallitus/cloud-base/pull/304